### PR TITLE
Add navigation cubit and refactor HomeScreen with Bloc

### DIFF
--- a/lib/core/routing/my_routes.dart
+++ b/lib/core/routing/my_routes.dart
@@ -9,7 +9,6 @@ class MyRoute
     SplashScreen.id: (context) => const SplashScreen(),
     HomeScreen.id: (context) =>const HomeScreen(),
 
-
   };
 
 }

--- a/lib/core/themes/my_assets.dart
+++ b/lib/core/themes/my_assets.dart
@@ -1,4 +1,6 @@
 class MyAssets
 {
   static const String splashLogo="assets/images/splashLogo.png";
+  static const String svgWatchlist="assets/svg/Icon ionic-md-bookmarks.svg";
+  static const String svgBrowse="assets/svg/Icon material-movie.svg";
 }

--- a/lib/features/browse_tap_feature/presentation/pages/browse_tap.dart
+++ b/lib/features/browse_tap_feature/presentation/pages/browse_tap.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class BrowseTap extends StatelessWidget {
+  const BrowseTap({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('Browse',style: TextStyle(color: Colors.white),)),
+    );
+  }
+}

--- a/lib/features/home_features/presentation/manager/nav_cubit/nav_cubit.dart
+++ b/lib/features/home_features/presentation/manager/nav_cubit/nav_cubit.dart
@@ -1,0 +1,59 @@
+
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:google_nav_bar/google_nav_bar.dart';
+import 'package:line_icons/line_icons.dart';
+import 'package:movies_app/features/browse_tap_feature/presentation/pages/browse_tap.dart';
+import 'package:movies_app/features/home_features/presentation/manager/nav_cubit/nav_state.dart';
+import 'package:movies_app/features/home_tap_feature/presentation/pages/home_tap.dart';
+import 'package:movies_app/features/profile_tap_feature/presentation/pages/profile_tap.dart';
+import 'package:movies_app/features/search_tap_feature/presentation/pages/search_tap.dart';
+import 'package:movies_app/features/watch_list_feature/presentation/pages/watch_list.dart';
+
+
+class NavCubit extends Cubit<NavState> {
+  NavCubit() : super(NavInitial());
+  static NavCubit get(context)=>BlocProvider.of(context);
+
+  List<GButton>gnav=[
+    const GButton(
+      icon: LineIcons.home,
+      text: 'Home',
+    ),
+    const GButton(
+      icon: LineIcons.search,
+      text: 'Search',
+    ),
+    const GButton(
+      icon:Icons.playlist_play,
+      text: 'Browse',
+    ),
+    const GButton(
+      icon: LineIcons.heart,
+      text: 'Likes',
+    ),
+    const GButton(
+      icon: LineIcons.user,
+      text: 'Profile',
+    )
+  ];
+
+  List<Widget>listOfBoby=[
+    const HomeTap(),
+    const SearchTap(),
+    const BrowseTap(),
+    const WatchList(),
+    const ProfileTap(),
+  ];
+
+
+  int selectedTap=0;
+
+  void onTap(int index){
+    selectedTap=index;
+    emit(NavChanged());
+  }
+
+
+}

--- a/lib/features/home_features/presentation/manager/nav_cubit/nav_state.dart
+++ b/lib/features/home_features/presentation/manager/nav_cubit/nav_state.dart
@@ -1,0 +1,4 @@
+class NavState {}
+
+final class NavInitial extends NavState {}
+final class NavChanged extends NavState {}

--- a/lib/features/home_features/presentation/pages/home_screen.dart
+++ b/lib/features/home_features/presentation/pages/home_screen.dart
@@ -1,51 +1,29 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:google_nav_bar/google_nav_bar.dart';
-import 'package:line_icons/line_icons.dart';
-import 'package:movies_app/core/themes/my_colors.dart';
-
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:movies_app/features/home_features/presentation/manager/nav_cubit/nav_cubit.dart';
+import 'package:movies_app/features/home_features/presentation/manager/nav_cubit/nav_state.dart';
+import 'package:movies_app/features/home_features/presentation/widgets/g_nav_bar.dart';
 
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
-  static const String id="HomeScreen";
 
+  static const String id = "HomeScreen";
 
   @override
   Widget build(BuildContext context) {
-    return  Scaffold(
-      bottomNavigationBar:Padding(
-        padding: EdgeInsetsDirectional.symmetric(horizontal: 10.w, vertical: 10.h),
-        child: GNav(
-            tabBorderRadius: 15,
-            tabActiveBorder: Border.all(color: const Color(0xff232023), width: 1), // tab button border
-            curve: Curves.easeInExpo, // tab animation curves
-            duration: const Duration(milliseconds: 800),
-            gap: 8,
-            color: Colors.grey,
-            activeColor: MyColors.yellowColor,
-            tabBackgroundColor: const Color(0xff232023),
-            padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 5.h), // navigation bar padding
-
-            tabs:  const [
-          GButton(
-            icon: LineIcons.home,
-            text: 'Home',
-          ),
-          GButton(
-            icon: LineIcons.heart,
-            text: 'Likes',
-          ),
-          GButton(
-            icon: LineIcons.search,
-            text: 'Search',
-          ),
-          GButton(
-            icon: LineIcons.user,
-            text: 'Profile',
-          )
-        ]),
-      )
+    return BlocProvider(
+      create: (context) => NavCubit(),
+      child: BlocBuilder<NavCubit,NavState>(
+        builder: (context, state) {
+          NavCubit cubit=NavCubit.get(context);
+          return Scaffold(
+            body: cubit.listOfBoby[cubit.selectedTap],
+              bottomNavigationBar: GNavBar(cubit:cubit,));
+        },
+      ),
     );
   }
 }
+
+

--- a/lib/features/home_features/presentation/widgets/g_nav_bar.dart
+++ b/lib/features/home_features/presentation/widgets/g_nav_bar.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:google_nav_bar/google_nav_bar.dart';
+import 'package:movies_app/core/themes/my_colors.dart';
+
+import '../manager/nav_cubit/nav_cubit.dart';
+
+class GNavBar extends StatelessWidget {
+  const GNavBar({
+    super.key,
+    required this.cubit,
+  });
+  final NavCubit cubit;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding:
+          EdgeInsetsDirectional.symmetric(horizontal: 10.w, vertical: 10.h),
+      child: GNav(
+          tabBorderRadius: 15,
+          tabActiveBorder: Border.all(color: const Color(0xff232023), width: 1),
+          curve: Curves.easeInExpo, // tab animation curves
+          duration: const Duration(milliseconds: 800),
+          gap: 8,
+          color: Colors.grey,
+          activeColor: MyColors.yellowColor,
+          tabBackgroundColor: const Color(0xff232023),
+          padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 5.h),
+          selectedIndex: cubit.selectedTap,
+          onTabChange: cubit.onTap,
+          tabs: cubit.gnav),
+    );
+  }
+}

--- a/lib/features/home_tap_feature/presentation/pages/home_tap.dart
+++ b/lib/features/home_tap_feature/presentation/pages/home_tap.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class HomeTap extends StatelessWidget {
+  const HomeTap({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('Home_Tap',style: TextStyle(color: Colors.white),)),
+    );
+  }
+}

--- a/lib/features/profile_tap_feature/presentation/pages/profile_tap.dart
+++ b/lib/features/profile_tap_feature/presentation/pages/profile_tap.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ProfileTap extends StatelessWidget {
+  const ProfileTap({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('profileTap',style: TextStyle(color: Colors.white),)),
+    );
+  }
+}

--- a/lib/features/search_tap_feature/presentation/pages/search_tap.dart
+++ b/lib/features/search_tap_feature/presentation/pages/search_tap.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class SearchTap extends StatelessWidget {
+  const SearchTap({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('Search_Tap',style: TextStyle(color: Colors.white),)),
+    );
+  }
+}

--- a/lib/features/watch_list_feature/presentation/pages/watch_list.dart
+++ b/lib/features/watch_list_feature/presentation/pages/watch_list.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class WatchList extends StatelessWidget {
+  const WatchList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('WatchList_Tap',style: TextStyle(color: Colors.white),)),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  bloc:
+    dependency: "direct main"
+    description:
+      name: bloc
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -70,6 +78,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.6"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -187,6 +203,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -211,6 +235,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   flutter_svg: ^2.0.10+1
   google_nav_bar: ^5.0.6
   line_icons: ^2.0.3
+  bloc: ^8.1.4
+  flutter_bloc: ^8.1.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Introduce `NavCubit` for managing navigation state.
- Refactor `HomeScreen` to use `BlocProvider` and `BlocBuilder`.
- Create `GNavBar` widget for bottom navigation bar.
- Add new pages for different tabs: `HomeTap`, `SearchTap`, `BrowseTap`, `WatchList`, and `ProfileTap`.
- Update dependencies in `pubspec.yaml` to include `bloc` and `flutter_bloc`.
- Add new assets in `MyAssets`.
![home](https://github.com/user-attachments/assets/93dc4a38-a3f5-497d-a530-bc3df7c36759)
![profile](https://github.com/user-attachments/assets/89cda258-467f-4962-977a-785d6e713804)
