### PR TITLE
Add trailer feature with UI, state management, and YouTube integration

### DIFF
--- a/lib/core/routing/my_routes.dart
+++ b/lib/core/routing/my_routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:movies_app/features/browse_tap_feature/presentation/pages/movie_category.dart';
 import 'package:movies_app/features/detailes_feature/presentation/pages/details_screen.dart';
+import 'package:movies_app/features/detailes_feature/presentation/pages/trailer_creen.dart';
 import 'package:movies_app/features/home_features/presentation/pages/home_screen.dart';
 import 'package:movies_app/features/splash_screen/presentation/pages/splash_screen.dart';
 
@@ -12,7 +13,7 @@ class MyRoute
     HomeScreen.id: (context) =>const HomeScreen(),
     DetailsScreen.id: (context) =>const DetailsScreen(),
     MovieCategory.id: (context) =>const MovieCategory(),
-
+    TrailerScreen.routeName: (context) =>const TrailerScreen(),
   };
 
 }

--- a/lib/features/detailes_feature/data/models/details_model/trailer_model.dart
+++ b/lib/features/detailes_feature/data/models/details_model/trailer_model.dart
@@ -1,0 +1,80 @@
+class TrailerModel {
+  TrailerModel({
+      this.id, 
+      this.results,});
+
+  TrailerModel.fromJson(dynamic json) {
+    id = json['id'];
+    if (json['results'] != null) {
+      results = [];
+      json['results'].forEach((v) {
+        results?.add(Results.fromJson(v));
+      });
+    }
+  }
+  num? id;
+  List<Results>? results;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    map['id'] = id;
+    if (results != null) {
+      map['results'] = results?.map((v) => v.toJson()).toList();
+    }
+    return map;
+  }
+
+}
+
+class Results {
+  Results({
+      this.iso6391, 
+      this.iso31661, 
+      this.name, 
+      this.key, 
+      this.site, 
+      this.size, 
+      this.type, 
+      this.official, 
+      this.publishedAt, 
+      this.id,});
+
+  Results.fromJson(dynamic json) {
+    iso6391 = json['iso_639_1'];
+    iso31661 = json['iso_3166_1'];
+    name = json['name'];
+    key = json['key'];
+    site = json['site'];
+    size = json['size'];
+    type = json['type'];
+    official = json['official'];
+    publishedAt = json['published_at'];
+    id = json['id'];
+  }
+  String? iso6391;
+  String? iso31661;
+  String? name;
+  String? key;
+  String? site;
+  num? size;
+  String? type;
+  bool? official;
+  String? publishedAt;
+  String? id;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    map['iso_639_1'] = iso6391;
+    map['iso_3166_1'] = iso31661;
+    map['name'] = name;
+    map['key'] = key;
+    map['site'] = site;
+    map['size'] = size;
+    map['type'] = type;
+    map['official'] = official;
+    map['published_at'] = publishedAt;
+    map['id'] = id;
+    return map;
+  }
+
+}

--- a/lib/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo.dart
+++ b/lib/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo.dart
@@ -1,0 +1,10 @@
+import 'package:dartz/dartz.dart';
+import 'package:movies_app/features/detailes_feature/data/models/details_model/trailer_model.dart';
+import '../../../../../core/networking/failure.dart';
+
+
+
+abstract class GetTrailerRepo {
+  Future<Either<Failure,Results>>getTrailerMovie({required int id});
+
+}

--- a/lib/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo_imp.dart
+++ b/lib/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo_imp.dart
@@ -1,0 +1,31 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:movies_app/core/networking/failure.dart';
+import 'package:movies_app/features/detailes_feature/data/models/details_model/trailer_model.dart';
+import 'package:movies_app/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo.dart';
+import '../../../../../core/networking/api_const.dart';
+import '../../../../../core/networking/dio_helper.dart';
+
+class GetTrailerRepoImp implements GetTrailerRepo{
+  @override
+  Future<Either<Failure, Results>> getTrailerMovie({required int id}) async {
+    try {
+      Response response = await DioHelper.getData(
+          endPoint: "movie/$id/videos", token: ApiConst.token);
+      Map<String, dynamic>data = response.data;
+      List<Results>trailer=[];
+      for(var item in data["results"])
+        {
+          trailer.add(Results.fromJson(item));
+        }
+      return right(trailer[0]);
+    }catch(e) {
+      if(e is DioException)
+      {
+        return Left(ServerFailure.fromDiorError(e));
+      }
+      return left(ServerFailure(e.toString()));
+    }
+  }
+
+}

--- a/lib/features/detailes_feature/presentation/manager/get_tariler_cubit/get_trailer_cubit.dart
+++ b/lib/features/detailes_feature/presentation/manager/get_tariler_cubit/get_trailer_cubit.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:movies_app/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo.dart';
+
+import 'get_trailer_state.dart';
+
+class GetTrailerCubit extends Cubit<GetTrailerState> {
+  GetTrailerCubit(this.getTrailerRepo) : super(GetTrailerInitial());
+  final GetTrailerRepo getTrailerRepo;
+
+  Future<void> getTrailer({required int  id}) async {
+    emit(GetTrailerLoading());
+    var result = await getTrailerRepo.getTrailerMovie(id: id);
+    result.fold((e){
+      emit(GetTrailerFailure(error: e.message));
+    }, (trailer){
+      emit(GetTrailerSucess(trailer: trailer));
+    });
+  }
+}

--- a/lib/features/detailes_feature/presentation/manager/get_tariler_cubit/get_trailer_state.dart
+++ b/lib/features/detailes_feature/presentation/manager/get_tariler_cubit/get_trailer_state.dart
@@ -1,0 +1,16 @@
+import 'package:movies_app/features/detailes_feature/data/models/details_model/trailer_model.dart';
+
+class GetTrailerState {}
+
+class GetTrailerInitial extends GetTrailerState {}
+class GetTrailerLoading extends GetTrailerState {}
+class GetTrailerSucess extends GetTrailerState {
+  final Results trailer;
+
+  GetTrailerSucess({required this.trailer});
+}
+class GetTrailerFailure extends GetTrailerState {
+  final String error;
+
+  GetTrailerFailure({required this.error});
+}

--- a/lib/features/detailes_feature/presentation/pages/trailer_creen.dart
+++ b/lib/features/detailes_feature/presentation/pages/trailer_creen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter/services.dart';
+import 'package:movies_app/core/themes/my_colors.dart';
+import 'package:movies_app/features/detailes_feature/data/repositories/get_trailer_repo/get_trailer_repo_imp.dart';
+import 'package:movies_app/features/detailes_feature/presentation/manager/get_tariler_cubit/get_trailer_cubit.dart';
+import 'package:movies_app/features/detailes_feature/presentation/manager/get_tariler_cubit/get_trailer_state.dart';
+import 'package:youtube_player_flutter/youtube_player_flutter.dart';
+
+class TrailerScreen extends StatefulWidget {
+  const TrailerScreen({super.key});
+  static const String routeName = "trailer";
+
+  @override
+  _TrailerScreenState createState() => _TrailerScreenState();
+}
+
+class _TrailerScreenState extends State<TrailerScreen> {
+  late YoutubePlayerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([DeviceOrientation.landscapeLeft, DeviceOrientation.landscapeRight]);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    int id = ModalRoute.of(context)!.settings.arguments as int;
+    return BlocProvider(
+      create: (context) => GetTrailerCubit(GetTrailerRepoImp())..getTrailer(id: id),
+      child: Scaffold(
+        body: BlocBuilder<GetTrailerCubit, GetTrailerState>(
+          builder: (context, state) {
+            if (state is GetTrailerSucess) {
+              _controller = YoutubePlayerController(
+                initialVideoId: state.trailer.key ?? "",
+                flags: const YoutubePlayerFlags(
+                  autoPlay: true,
+                  mute: false,
+                ),
+              );
+
+              return Center(
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: YoutubePlayer(
+                    controller: _controller,
+                    showVideoProgressIndicator: true,
+                    onReady: () {
+                      _controller.play();
+                    },
+                  ),
+                ),
+              );
+            } else if (state is GetTrailerFailure) {
+              return const Center(
+                child: Text(
+                  'Failed to load trailer',
+                  style: TextStyle(color: Colors.white),
+                ),
+              );
+            }
+            return const Center(
+              child: CircularProgressIndicator(
+                color: MyColors.yellowColor,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/detailes_feature/presentation/widgets/details_section.dart
+++ b/lib/features/detailes_feature/presentation/widgets/details_section.dart
@@ -3,15 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:movies_app/features/browse_tap_feature/presentation/pages/movie_category.dart';
 import 'package:movies_app/features/detailes_feature/data/repositories/details_repo/details_repo_imp.dart';
 import 'package:movies_app/features/detailes_feature/presentation/manager/details_cubit/details_cubit.dart';
 import 'package:movies_app/features/detailes_feature/presentation/manager/details_cubit/details_state.dart';
+import 'package:movies_app/features/detailes_feature/presentation/pages/trailer_creen.dart';
 import 'package:movies_app/features/home_features/presentation/pages/home_screen.dart';
 import '../../../../core/networking/api_const.dart';
 import '../../../../core/themes/my_assets.dart';
 import '../../../../core/themes/my_colors.dart';
 import '../../../../core/themes/my_styles.dart';
 import '../../../../core/widgets/watch_list_componant.dart';
+import '../../../browse_tap_feature/data/models/navigation_model/navigation_model.dart';
 
 class DetailsSection extends StatelessWidget {
   const DetailsSection({
@@ -127,25 +130,28 @@ class DetailsSection extends StatelessWidget {
                                       scrollDirection: Axis.horizontal,
                                       physics: const BouncingScrollPhysics(),
                                       itemBuilder: (context, index) =>
-                                          Container(
+                                          GestureDetector(
+                                            onTap: () =>Navigator.pushNamed(context,MovieCategory.id,arguments:NavigationModel(name:state.model.genres![index].name??"" , id:state.model.genres![index].id??"")),
+                                            child: Container(
 
-                                            height: 30.h,
-                                            decoration: ShapeDecoration(
-                                              shape: RoundedRectangleBorder(
-                                                borderRadius:
-                                                BorderRadius.circular(5.w),
-                                                side: const BorderSide(
-                                                    color: MyColors
-                                                        .bookMarkOffColor),
+                                              height: 30.h,
+                                              decoration: ShapeDecoration(
+                                                shape: RoundedRectangleBorder(
+                                                  borderRadius:
+                                                  BorderRadius.circular(5.w),
+                                                  side: const BorderSide(
+                                                      color: MyColors
+                                                          .bookMarkOffColor),
+                                                ),
                                               ),
-                                            ),
-                                            child: Padding(
-                                              padding:  EdgeInsetsDirectional.symmetric(horizontal: 8.w),
-                                              child: Center(
-                                                child: Text(
-                                                  "${state.model.genres![index].name}",
-                                                  style: MyStyles
-                                                      .font10GreyPoppens,
+                                              child: Padding(
+                                                padding:  EdgeInsetsDirectional.symmetric(horizontal: 8.w),
+                                                child: Center(
+                                                  child: Text(
+                                                    "${state.model.genres![index].name}",
+                                                    style: MyStyles
+                                                        .font10GreyPoppens,
+                                                  ),
                                                 ),
                                               ),
                                             ),
@@ -201,7 +207,7 @@ class DetailsSection extends StatelessWidget {
                     ),
                       backgroundColor: MyColors.greyColor.withOpacity(0.5),
                       onPressed: () {
-
+                      Navigator.pushNamed(context,TrailerScreen.routeName,arguments: id);
                       },
                   child:  const Icon(Icons.play_arrow,color: MyColors.yellowColor,)),
                 )

--- a/lib/features/home_tap_feature/presentation/pages/home_tap.dart
+++ b/lib/features/home_tap_feature/presentation/pages/home_tap.dart
@@ -9,15 +9,16 @@ class HomeTap extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return
-      const Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          CarsoulSlider(),
-          ReleaseSection(),
-          RecommendedSection()
-
-
-        ],
+      const SingleChildScrollView(
+        physics: BouncingScrollPhysics(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CarsoulSlider(),
+            ReleaseSection(),
+            RecommendedSection(),
+          ],
+        ),
       );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,6 +182,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_inappwebview:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview
+      sha256: "3e9a443a18ecef966fb930c3a76ca5ab6a7aafc0c7b5e14a4a850cf107b09959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_inappwebview_android:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_android
+      sha256: d247f6ed417f1f8c364612fa05a2ecba7f775c8d0c044c1d3b9ee33a6515c421
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.13"
+  flutter_inappwebview_internal_annotations:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_internal_annotations
+      sha256: "5f80fd30e208ddded7dbbcd0d569e7995f9f63d45ea3f548d8dd4c0b473fb4c8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  flutter_inappwebview_ios:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_ios
+      sha256: f363577208b97b10b319cd0c428555cd8493e88b468019a8c5635a0e4312bd0f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.13"
+  flutter_inappwebview_macos:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_macos
+      sha256: b55b9e506c549ce88e26580351d2c71d54f4825901666bd6cfa4be9415bb2636
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
+  flutter_inappwebview_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_platform_interface
+      sha256: "545fd4c25a07d2775f7d5af05a979b2cac4fbf79393b0a7f5d33ba39ba4f6187"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.10"
+  flutter_inappwebview_web:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_web
+      sha256: d8c680abfb6fec71609a700199635d38a744df0febd5544c5a020bd73de8ee07
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -208,6 +264,11 @@ packages:
     version: "2.0.10+1"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -251,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   leak_tracker:
     dependency: transitive
     description:
@@ -600,6 +669,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  youtube_player_flutter:
+    dependency: "direct main"
+    description:
+      name: youtube_player_flutter
+      sha256: b670314008a9abd051f01f82df754d76fd1366340f03f4f8ff86fc3d6b03080c
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.3"
 sdks:
   dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   dartz: ^0.10.1
   cached_network_image: ^3.4.1
   google_fonts: ^6.2.1
+  youtube_player_flutter: ^9.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add TrailerScreen widget for trailer playback
- Integrate YouTube player for trailer videos
- Add TrailerModel for trailer data representation
- Implement GetTrailerRepo and GetTrailerRepoImp for fetching trailer data
- Add GetTrailerCubit and GetTrailerState for state management
- Update DetailsSection to navigate to TrailerScreen on play button click
- Add youtube_player_flutter dependency
- Update routes to include TrailerScreen
- Wrap HomeTap content in SingleChildScrollView for better scrolling experience
- 
![trailer 1](https://github.com/user-attachments/assets/5b1f84e2-4055-456c-adcd-e9ab50226408)
![trailer](https://github.com/user-attachments/assets/0b319eac-21f6-41af-9eb3-3ec7b10cc292)
